### PR TITLE
Ignore changes to replied_to file on deploy

### DIFF
--- a/planbot.tf
+++ b/planbot.tf
@@ -139,6 +139,8 @@ resource "google_storage_bucket_object" "plan_bot_plans_replied_to" {
   bucket = google_storage_bucket.plan_bot_other_storage.name
   source = "${path.root}/src/posts_replied_to.txt"
   lifecycle {
-    prevent_destroy = true
+    ignore_changes = [
+      "detect_md5hash"
+    ]
   }
 }


### PR DESCRIPTION
Rather than prevent_destroy, which made a generic `terraform apply` not work