### PR TITLE
Add metadata to db entries

### DIFF
--- a/src/plan_bot.py
+++ b/src/plan_bot.py
@@ -76,9 +76,20 @@ def process_post(
             plan_confidence = match_info["confidence"]
             plan = match_info["plan"]
             plan_id = plan["id"]
+            post_parent_id = False # Could be "" unless constructing URLs with it later
+            post_title = False # Could be "" unless constructing URLs with it later
+            post_top_level_parent_id = False
 
-            # If plan is matched with confidence, build and send reply
-            if match:
+            if(self.type == "comment"):
+                # Reddit 3-digit code prefix removed for each id, leaving only the ID itself
+                post_parent_id = post.parent_id([3:])
+                post_top_level_parent_id = post.link_id([3:])
+            
+            if(self.type = "submission"):
+                post_title = post.title
+            
+            # If plan is matched with confidence, build and send reply if post not locked
+            if match and not post.locked:
                 print("plan match: ", plan_id, post.id, plan_confidence)
 
                 reply_string = build_response_text(plan, post)
@@ -86,15 +97,22 @@ def process_post(
                 did_reply = reply(post, reply_string, send=send, simulate=simulate)
 
                 if did_reply and not skip_tracking:
+                    
                     posts_db.document(post.id).set(
                         {
                             # TODO add more info about the match here
                             "replied": True,
                             "type": post.type,
+                            "post_author": "/u/" + post.author,
                             "post_text": post.text,
-                            "post_url": post.permalink,
-                            "plan_match": match,
+                            "post_parent_id": post_parent_id,   # ID or False if no parent_id
+                            "post_url": "https://www.reddit.com" + post.permalink,
+                            "post_subreddit": post.subreddit,
+                            "post_title": post_title,           # Post Title or False if no title
+                            "post_top_level_parent_id": post_top_level_parent_id,
+
                             # TODO flesh out / clarify this some
+                            "plan_match": match,
                             "top_plan_confidence": plan_confidence,
                             "top_plan": plan_id,
                             "reply_timestamp": firestore.SERVER_TIMESTAMP,
@@ -107,8 +125,15 @@ def process_post(
                         # TODO add more info about the match here
                         "replied": False,
                         "type": post.type,
+                        "post_author": "/u/" + post.author,
                         "post_text": post.text,
-                        "post_url": post.permalink,
+                        "post_parent_id": post_parent_id,   # ID or False if no parent_id
+                        "post_url": "https://www.reddit.com" + post.permalink,
+                        "post_subreddit": post.subreddit,
+                        "post_title": post_title,           # Post Title or False if no title
+                        "post_locked": post.locked
+
+                        # TODO flesh out / clarify this some
                         "plan_match": match,
                         "top_plan_confidence": plan_confidence,
                         "top_plan": plan_id,


### PR DESCRIPTION
- added the following metadata  from posts to posts_db entry log:
    - post_author: username of post author in the format of /u/$author, allows for linking to the user in response
    - post_url: added "https://www.reddit.com" to the permalink for fully formed URL
    - post_subreddit: name of subreddit where the post is located for checking against 'disallowed' subreddits
    - post_parent_id: parent of the post, allows for replying directly to the post the query request was made in response to (need to explore how useful or appropriate this is)(Comments only)
        - Default: False
    - post_top_level_parent_id: id for top-level submission a comment is found in (Comments only)
        - Default: False
    - post_title: Title of the post if it is a top-level submission (Submissions only)
        - Default: False
- Added condition to posts with matched topics to ensure they're not locked before attempting to reply
    - Added post_locked property to posts_db entry for posts when replied == false to distinguish between replies not made because the match failed or because the post was locked.  

Should address most, if not all of Issue #23 