### PR TITLE
Add db entries for mismatched queries

### DIFF
--- a/src/plan_bot.py
+++ b/src/plan_bot.py
@@ -100,7 +100,7 @@ def process_post(
 
                     posts_db.document(post.id).set(db_data)
         else:
-            print ("plan mismatch: ", plan_id, post.id, plan_confidence)
+            print("plan mismatch: ", plan_id, post.id, plan_confidence)
             posts_db.document(post.id).set(db_data)
 
 

--- a/src/plan_bot.py
+++ b/src/plan_bot.py
@@ -99,6 +99,9 @@ def process_post(
                     print("topic mismatch: ", plan_id, post.id, plan_confidence)
 
                     posts_db.document(post.id).set(db_data)
+        else:
+            print ("plan mismatch: ", plan_id, post.id, plan_confidence)
+            posts_db.document(post.id).set(db_data)
 
 
 def create_db_record(


### PR DESCRIPTION
- Added posts_db entry for queries that don't have plan match or match is below the confidence threshold.

Should close #51 at least for now.  Could still write to a different Firestore collection for easier parsing of unmatched plan info.