### PR TITLE
Add criminal justice plan, modify fuzz matching

### DIFF
--- a/src/matching.py
+++ b/src/matching.py
@@ -52,7 +52,7 @@ class Strategy:
         match = None
 
         for plan in plans:
-            plan_match_confidence = fuzz.token_sort_ratio(post.text, plan["topic"])
+            plan_match_confidence = fuzz.token_sort_ratio(post.text.lower(), plan["topic"].lower())
 
             if plan_match_confidence > match_confidence:
                 # Update match

--- a/src/plans.json
+++ b/src/plans.json
@@ -260,5 +260,12 @@
         "display_title": "Fulfilling our Obligations to Tribal Nations and Indigenous Peoples",
         "url": "https://medium.com/@teamwarren/honoring-and-empowering-tribal-nations-and-indigenous-peoples-720e49e1d1ca",
         "keyword_synonyms": []
+    }, {
+        "id": "comprehensive_criminal_justice_reform",
+        "topic": "comprehensive criminal justice reform",
+        "summary": "We will reduce incarceration and improve justice in our country by changing what we choose to criminalize, reforming police behavior and improving police-community relations, and reining in a system that preferences prosecution over justice. When people are incarcerated, we will provide opportunities for treatment, education and rehabilitation, and we’ll continue those supports for returning citizens as they reenter our communities. Most importantly, we’ll rethink the way we approach public safety — emphasizing preventative approaches over law enforcement and incarceration. That’s the way we’ll create real law and order and real justice in our country.",
+        "display_title": "Rethinking Public Safety to Reduce Mass Incarceration and Strengthen Communities",
+        "url": "hhttps://medium.com/@teamwarren/rethinking-public-safety-to-reduce-mass-incarceration-and-strengthen-communities-90e8591c6255",
+        "keyword_synonyms": []
     }
 ]


### PR DESCRIPTION
- Changes text to lower for fuzz token sort ratio
    - Preliminary checks show scores may have a slightly lower score in some cases (less than 0.1 difference) up to a gain of 5+points with this change.
    - A more detailed review of posts_db with before/after scores would be helpful to quantify the benefit of normalizing the text to lower.
    - Additional considerations and tests should be used to determine the effect of further text normalization on input query on current matching algorithms.
- Adds new plan for criminal justice reform to plans.json