### PR TITLE
Update Plan display titles to match ewarren.com/plans

### DIFF
--- a/src/plan_bot.py
+++ b/src/plan_bot.py
@@ -105,7 +105,7 @@ def build_all_plans_response_text(plans, post):
     pure_plans = list(filter(lambda p: not p.get("is_cluster"), plans))
 
     response = (
-        f"Here's the full list of plans that Sen. Warren has released that I know about:"
+        f"Here's the full list of plans Sen. Warren has released that I know about:"
         f"\n\n"
         f"|[{pure_plans[0]['display_title']}]({pure_plans[0]['url']})|[{pure_plans[1]['display_title']}]({pure_plans[1]['url']})|[{pure_plans[2]['display_title']}]({pure_plans[2]['url']})|"
         f"\n"

--- a/src/plans.json
+++ b/src/plans.json
@@ -58,7 +58,7 @@
         "id": "election_reform",
         "topic": "election reform",
         "summary": "It's time to make voting easy and convenient, stop racist voter suppression, and secure our elections. Sen. Warren's plan creates uniform federal rules to make voting easy for everyone - no registration problems, no purges, no difficulties voting, and no gerrymandering - and we'll have federal funding to make sure our elections are secure from hacking.",
-        "display_title": "Her Plan to Strengthen Our Democracy",
+        "display_title": "My Plan to Strengthen Our Democracy",
         "url": "https://medium.com/@teamwarren/my-plan-to-strengthen-our-democracy-6867ec1bcd3c",
         "keyword_synonyms": []
     },
@@ -82,7 +82,7 @@
         "id": "economic_patriotism",
         "topic": "American jobs",
         "summary": "For decades, we've let giant corporations run our economy even though they have no loyalty or allegiance to America. Not on her watch. She will use all the tools of government to defend and create good American jobs.",
-        "display_title": "The New American Patriotism",
+        "display_title": "The New American Economic Patriotism",
         "url": "https://medium.com/@teamwarren/a-plan-for-economic-patriotism-13b879f4cfc7",
         "keyword_synonyms": []
     },
@@ -90,7 +90,7 @@
         "id": "green_manufacturing",
         "topic": "green energy jobs",
         "summary": "By investing $2 trillion in American research and American manufacturing of clean energy technology, we can lead the global effort to combat climate change, boost our economy, and create more than a million good jobs here at home.",
-        "display_title": "A Green Manufacturing Plan",
+        "display_title": "Elizabeth's Green Manufacturing Plan",
         "url": "https://medium.com/@teamwarren/my-green-manufacturing-plan-for-america-fc0ad53ab614",
         "keyword_synonyms": []
     },
@@ -98,7 +98,7 @@
         "id": "presidential_accountability",
         "topic": "crimes by the president",
         "summary": "Impeachment isn't supposed to be the only way that a President can be held accountable for committing a crime. Congress should make it clear that Presidents can be indicted for criminal activity, including obstruction of justice. And when She'sPresident, she will appoint Justice Department officials who will reverse flawed policies so no President is shielded from criminal accountability.",
-        "display_title": "Plan to Make Sure That No President is Above the Law",
+        "display_title": "Elizabeth's Plan to Make Sure That No President is Above the Law",
         "url": "https://medium.com/@teamwarren/no-president-is-above-the-law-f4812e580336",
         "keyword_synonyms": []
     },
@@ -138,7 +138,7 @@
         "id": "puerto_rico_debt_relief",
         "topic": "Puerto Rico debt relief",
         "summary": "After Hurricanes Irma and Maria devastated Puerto Rico, one of the biggest constraints holding back the island's recovery has been its debt. If Puerto Rico were a big company or an American city, it could file for bankruptcy, but because of its unique status, those legal options aren't available. That's why She has a plan to provide comprehensive debt relief to Puerto Rico so it can rebuild and thrive.",
-        "display_title": "Providing Debt Relief for Puerto Rico",
+        "display_title": "Elizabeth's Plan to Provide Debt Relief for Puerto Rico",
         "url": "https://medium.com/@teamwarren/my-plan-to-provide-comprehensive-debt-relief-to-puerto-rico-f8b575a81b06",
         "keyword_synonyms": []
     },
@@ -154,7 +154,7 @@
         "id": "military_housing",
         "topic": "military housing",
         "summary": "Our military families have been raising the alarm about their living conditions for years. This stops now. She has a plan to improve our military housing, protect families from abuse, and hold private developers accountable for the promises they make to those who serve our country.",
-        "display_title": "Improving Our Military Housing",
+        "display_title": "Elizabeth’s Plan to Improve Our Military Housing",
         "url": "https://medium.com/@teamwarren/my-plan-to-improve-our-military-housing-b1a46ba235b8",
         "keyword_synonyms": []
     },
@@ -162,7 +162,7 @@
         "id": "public_land",
         "topic": "public land management",
         "summary": "She's making a promise. On the first day of a Warren administration, She will sign a moratorium so that there is no more drilling on public lands, and She will set a goal of providing 10 percent of our overall electricity generation from renewable sources. Climate change is here, it is real, and we should make our public lands part of the solution.",
-        "display_title": "Public Lands",
+        "display_title": "Elizabeth's Plan for Public Lands",
         "url": "https://medium.com/@teamwarren/my-plan-for-public-lands-e4be1d88a01c",
         "keyword_synonyms": []
     },
@@ -194,7 +194,7 @@
         "id": "electoral_college",
         "topic": "electoral college reform",
         "summary": "Presidential candidates should have to ask every American in every part of the country for their vote. We can make that happen by abolishing the Electoral College and replacing it with a national popular vote.",
-        "display_title": "Getting Rid of the Electoral College",
+        "display_title": "It's Time to Get Rid of the Electoral College",
         "url": "https://medium.com/@teamwarren/its-time-to-get-rid-of-the-electoral-college-20efcac09c5e",
         "keyword_synonyms": []
     },
@@ -202,7 +202,7 @@
         "id": "affordable_housing",
         "topic": "safe affordable housing",
         "summary": "Every American deserves a safe and affordable place to live. Her plan makes a historic investment in housing that would bring down rents by 10%, create 1.5 million new jobs, and begin closing the racial wealth gap.",
-        "display_title": "For Affordable Housing for America",
+        "display_title": "Elizabeth's Housing Plan for America",
         "url": "https://medium.com/@teamwarren/my-housing-plan-for-america-20038e19dc26",
         "keyword_synonyms": []
     },
@@ -210,7 +210,7 @@
         "id": "break_up_big_tech",
         "topic": "big tech companies",
         "summary": "America's biggest tech companies are controlling more and more of our digital lives and using their size and power to make it harder for the next tech entrepreneur with the next big idea to compete. It's time to break up the biggest tech companies to restore competition - and make sure these corporations don't get so powerful that they undermine our democracy.",
-        "display_title": "How We Can Break Up Big Tech",
+        "display_title": "Here's How We Can Break Up Big Tech",
         "url": "https://medium.com/@teamwarren/heres-how-we-can-break-up-big-tech-9ad9e0da324c",
         "keyword_synonyms": []
     },
@@ -218,7 +218,7 @@
         "id": "universal_child_care",
         "topic": "universal child care",
         "summary": "We're the wealthiest country on the planet - high-quality child care and early education shouldn't be a privilege that's only for the rich. She'sfighting to make high-quality child care from birth to school age free for millions of families and affordable for all.",
-        "display_title": "Universal Child Care",
+        "display_title": "Elizabeth's Plan for Universal Child Care",
         "url": "https://medium.com/@teamwarren/my-plan-for-universal-child-care-762535e6c20a",
         "keyword_synonyms": []
     },
@@ -250,14 +250,14 @@
         "id": "invest_in_rural_america",
         "topic": "invest in rural america",
         "summary": "Everyone should have the opportunity to build a good life wherever they live – but our failure to invest in rural areas is holding back millions of families, weakening our economy, and undermining our efforts to combat climate change. It’s time to fix this.  Her plan will put health care services in reach of every family, create a public option for broadband so every home and business has access to high-speed internet at an affordable price, and build a sustainable farm economy that raises farm incomes and protects our environment.",
-        "display_title": "Her Plan to Invest in Rural America",
+        "display_title": "My Plan to Invest in Rural America",
         "url": "https://medium.com/@teamwarren/my-plan-to-invest-in-rural-america-94e3a80d88aa",
         "keyword_synonyms": []
     }, {
         "id": "tribal_nations_and_indigenous_peoples",
         "topic": "native americans tribal lands indigenous peoples treaties",
         "summary": "Washington owes Tribal Nations and indigenous peoples respect, and a fighting chance to build stronger communities and a brighter future. We must ensure that America’s sacred trust and treaty obligations are the law of the land - binding legal and moral principles that are not merely slogans, but instead reinforce the solemn nation-to-nation relationships with Tribal Nations. Accomplishing this will require structural change.",
-        "display_title": "Fulfilling our Obligations to Tribal Nations and Indigenous Peoples",
+        "display_title": "Honoring and Empowering Tribal Nations and Indigenous Peoples",
         "url": "https://medium.com/@teamwarren/honoring-and-empowering-tribal-nations-and-indigenous-peoples-720e49e1d1ca",
         "keyword_synonyms": []
     }, {

--- a/src/plans.json
+++ b/src/plans.json
@@ -270,7 +270,7 @@
     }, {
         "id": "trade_on_our_terms",
         "topic": "trade",
-        "summary": "Trade can be a powerful tool to help working families but our failed pro-corporate agenda has used trade to harm American workers and the environment. Sen. Warren's plan represents a new approach to trade — one that uses America’s leverage to boost American workers and raise the standard of living across the globe. The President has a lot of authority to remake trade policy herself. When she's elected, she intends to use it.",
+        "summary": "Sen. Warren's plan represents a new approach to trade — one that uses America’s leverage to boost American workers and raise the standard of living across the globe. The President has a lot of authority to remake trade policy herself. When she's elected, she intends to use it.",
         "display_title": "Trade—On Our Terms",
         "url": "https://medium.com/@teamwarren/trade-on-our-terms-ad861879feca",
         "keyword_synonyms": []


### PR DESCRIPTION
With the current response text, the full plan name from the website works fine! 

And I prefer to use the language that's on the website since I'm not sure what kind of thought went in to exactly how to title each plan. May as well leverage whatever research the campaign did on what will sound best :)